### PR TITLE
DotDict lacks pickling functions

### DIFF
--- a/ortho/bash.py
+++ b/ortho/bash.py
@@ -216,10 +216,7 @@ def bash(command,log=None,cwd=None,inpipe=None,scroll=True,tag=None,
 			# protect against type issues
 			try: stdout = stdout.decode('utf-8')
 			except: pass
-	returnObject = DotDict(**{'stdout':stdout,'stderr':stderr,'code':proc.returncode})
-	if not returnObject:
-		print('error! returnObject is a NoneType!')
-	return returnObject
+	return DotDict(**{'stdout':stdout,'stderr':stderr,'code':proc.returncode})
 
 class TeeMultiplexer:
 	"""

--- a/ortho/bash.py
+++ b/ortho/bash.py
@@ -216,7 +216,10 @@ def bash(command,log=None,cwd=None,inpipe=None,scroll=True,tag=None,
 			# protect against type issues
 			try: stdout = stdout.decode('utf-8')
 			except: pass
-	return DotDict(**{'stdout':stdout,'stderr':stderr,'code':proc.returncode})
+	returnObject = DotDict(**{'stdout':stdout,'stderr':stderr,'code':proc.returncode})
+	if not returnObject:
+		print('error! returnObject is a NoneType!')
+	return returnObject
 
 class TeeMultiplexer:
 	"""

--- a/ortho/dotdict.py
+++ b/ortho/dotdict.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # vim: noet:ts=4:sts=4:sw=4
 
+import pickle
+
 class DotDict(dict):
 	"""
 	Use dots to access dictionary items.
@@ -22,3 +24,18 @@ class DotDict(dict):
 	def __dir__(self): 
 		return [i for i in self.keys() if i not in self._protect 
 			and isinstance(i,str_types)]
+
+	# thanks ChatGPT for these two functions (__getstate__ and __setstate__) --Brock
+	def __getstate__(self):
+        # convert the object state to a dictionary
+        state = self.__dict__.copy()
+        state['__class__'] = self.__class__.__name__
+        return state
+
+    def __setstate__(self, state):
+        # restore the object state from a dictionary
+        clsname = state.pop('__class__')
+        if clsname != self.__class__.__name__:
+            raise ValueError("Invalid class name: {}".format(clsname))
+        self.__dict__.update(state)
+


### PR DESCRIPTION
Had an issue with multiprocessing.pool.map() trying to return a DotDict from bash() and failing because the DotDict object is not pickle-able. This fixes that with some help from ChatGPT>